### PR TITLE
CVE-2021-45046: upgrade to log4j 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects {
 
   dependencies {
     compile 'net.sourceforge.argparse4j:argparse4j:0.5.0'
-    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
     compile 'org.apache.avro:avro:1.4.1'
     compile 'org.json:json:20140107'
     compile 'org.jolokia:jolokia-jvm:1.6.2'


### PR DESCRIPTION
A new less-critical vulnerability was found in Log4J which can lead to a denial-of-service attack. Upgrading to log4j 2.16.0 resolves this issue.